### PR TITLE
Updated some stuff related to Olive.Audit

### DIFF
--- a/Template/Website/Website.csproj
+++ b/Template/Website/Website.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.0.1" />
+    <PackageReference Include="Olive.Audit.DatabaseLogger" Version="1.0.29" />
     <PackageReference Include="Olive.Export" Version="1.0.18" />
     <PackageReference Include="Olive.Hangfire" Version="1.0.25" />
     <PackageReference Include="Olive.Mvc" Version="1.0.78" />

--- a/Template/Website/app_Start/Startup.cs
+++ b/Template/Website/app_Start/Startup.cs
@@ -16,6 +16,7 @@
 
         public override void ConfigureServices(IServiceCollection services)
         {
+           services.AddSingleton<Olive.Audit.ILogger>(new DatabaseLogger());
             base.ConfigureServices(services);
 
             AuthenticationBuilder.AddSocialAuth();


### PR DESCRIPTION
I had the option of placing `services.AddSingleton<Olive.Audit.ILogger>(new DatabaseLogger());` into Olive.MVC but as we might add more providers and placing this into Olive.MVC needed 2 more dependencies, I decided to put this right into the template for now. 