### PR TITLE
Default SQLServer instance

### DIFF
--- a/Template/Website/appsettings.json
+++ b/Template/Website/appsettings.json
@@ -1,7 +1,7 @@
-﻿{
+{
     "App.Resource.Version": "1.0.0.0",
     "ConnectionStrings": {
-        "AppDatabase": "Database=MY.PROJECT.NAME.Temp; Data Source=.\\SQLExpress;Integrated Security=SSPI;MultipleActiveResultSets=True;"
+        "AppDatabase": "Database=MY.PROJECT.NAME.Temp; Data Source=.\\;Integrated Security=SSPI;MultipleActiveResultSets=True;"
     },     
     "Authentication": {
         "Timeout": 30,


### PR DESCRIPTION
Now the project should use the default SQL server (Which most developers have it already installed so they don't need to change their con string) instance rather SQLexpress