### PR TITLE
Add responsive grid mixins

### DIFF
--- a/Template/Website/wwwroot/styles/FrontEnd-Modal.scss
+++ b/Template/Website/wwwroot/styles/FrontEnd-Modal.scss
@@ -1,1 +1,15 @@
 ﻿@import "imports/common";
+@import "imports/rgrid";
+
+/* Responsive Grid */
+@include media-breakpoint-down(md) {
+    .r-grid {
+        @include make-r-grid-flex-card-view;
+    }
+}
+
+@include media-breakpoint-up(lg) {
+    .r-grid {
+        @include make-r-grid-table-view;
+    }
+}

--- a/Template/Website/wwwroot/styles/FrontEnd.scss
+++ b/Template/Website/wwwroot/styles/FrontEnd.scss
@@ -1,5 +1,6 @@
 ﻿@import "imports/common";
 @import "imports/nav";
+@import "imports/rgrid";
 @import "imports/bootstrap-social";
 @import "imports/print";
 
@@ -44,3 +45,16 @@ footer { position: absolute; bottom: 0; width: 100%; background-color: $gray-dar
 }
 
 .typeahead__container { padding : 0.5rem 1rem; }
+
+/* Responsive Grid */
+@include media-breakpoint-down(md) {
+    .r-grid {
+        @include make-r-grid-flex-card-view;
+    }
+}
+
+@include media-breakpoint-up(lg) {
+    .r-grid {
+        @include make-r-grid-table-view;
+    }
+}

--- a/Template/Website/wwwroot/styles/imports/_rgrid.scss
+++ b/Template/Website/wwwroot/styles/imports/_rgrid.scss
@@ -1,0 +1,303 @@
+﻿@import "variables";
+
+/* 
+    Responsive Grid
+
+    Mixins:
+        - make-r-grid-table-view (display table, classic table)
+        - make-r-grid-flex-table-view (display flex)
+        - make-r-grid-card-view (display block)
+        - make-r-grid-flex-card-view (display flex, bootstrap 4 grid system)
+*/
+
+@mixin make-r-grid-table-view() {
+    display: table;
+    width: 100%;
+    max-width: 100%;
+    margin-bottom: $line-height-computed;
+    background-color: $body-bg;
+
+    .r-grid-head, .r-grid-body {
+        display: table-row-group;
+
+        .r-grid-head-row, .r-grid-row {
+            display: table-row;
+
+            .r-grid-head-cell, .r-grid-cell {
+                display: table-cell;
+                line-height: $line-height-base;
+                padding: $table-cell-padding;
+                vertical-align: top;
+
+                &.actions {
+                    white-space: nowrap;
+                    width: 1px;
+                    text-align: center;
+                }
+            }
+        }
+    }
+
+    .r-grid-head {
+        .r-grid-head-row {
+            .r-grid-head-cell {
+                border-bottom: 2px solid $table-border-color;
+                font-weight: bold;
+                vertical-align: bottom;
+            }
+        }
+    }
+
+    .r-grid-body {
+        .r-grid-row {
+            &:nth-of-type(odd) {
+                background-color: $table-accent-bg;
+            }
+
+            &:hover {
+                background-color: $table-hover-bg;
+            }
+
+            &:not(:first-child) .r-grid-cell {
+                border-top: 1px solid $table-border-color;
+            }
+
+            .r-grid-cell {
+
+                .cell-label {
+                    display: none;
+                }
+            }
+        }
+    }
+}
+
+@mixin make-r-grid-flex-table-view() {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    margin-bottom: $line-height-computed;
+    background-color: $body-bg;
+
+    .r-grid-head, .r-grid-body {
+        @include make-container;
+
+        .r-grid-head-row, .r-grid-row {
+            @include make-row;
+
+            .r-grid-head-cell, .r-grid-cell {
+                flex: 1;
+                line-height: $line-height-base;
+                padding: $table-cell-padding;
+                vertical-align: top;
+
+                &.actions {
+                    flex-grow: 0;
+                    flex-shrink: 1;
+                    white-space: nowrap;
+                    text-align: center;
+                }
+            }
+        }
+    }
+
+    .r-grid-head {
+        .r-grid-head-row {
+            .r-grid-head-cell {
+                border-bottom: 2px solid $table-border-color;
+                font-weight: bold;
+                vertical-align: bottom;
+            }
+        }
+    }
+
+    .r-grid-body {
+        .r-grid-row {
+            &:nth-of-type(odd) {
+                background-color: $table-accent-bg;
+            }
+
+            &:hover {
+                background-color: $table-hover-bg;
+            }
+
+            &:not(:first-child) .r-grid-cell {
+                border-top: 1px solid $table-border-color;
+            }
+
+            .r-grid-cell {
+
+                .cell-label {
+                    display: none;
+                }
+            }
+        }
+    }
+}
+
+@mixin make-r-grid-card-view() {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    margin-bottom: $line-height-computed;
+    background-color: $body-bg;
+    border: none;
+
+    .r-grid-head {
+        display: none;
+    }
+
+    .r-grid-body {
+        position: relative;
+        border: none;
+        display: block;
+
+        .r-grid-row {
+            border: 1px solid $table-border-color;
+            display: block;
+            float: none;
+            margin-bottom: $grid-gutter-width / 2;
+            padding: 0;
+            width: 100%;
+
+            &:nth-of-type(odd) {
+                background-color: $table-accent-bg;
+            }
+
+            &:hover {
+                background-color: $table-hover-bg;
+            }
+
+            .r-grid-cell {
+                border-top: 1px solid $table-border-color;
+                display: block;
+                line-height: $line-height-base;
+                padding: $table-cell-padding;
+                display: block;
+                width: 100%;
+
+                &:first-child {
+                    border: none;
+                }
+
+                .cell-label {
+                    display: block;
+                    font-weight: bold;
+
+                    a {
+                        color: $body-color;
+                        cursor: default;
+
+                        &:hover, &:focus, &:active {
+                            text-decoration: none;
+                        }
+                    }
+                }
+
+                &.actions {
+                    display: inline-block;
+                    text-align: center;
+                    white-space: nowrap;
+                    width: 100%;
+
+                    .cell-label {
+                        display: none;
+                    }
+                }
+            }
+        }
+    }
+}
+
+@mixin make-r-grid-flex-card-view() {
+    @include make-container;
+    background-color: $body-bg;
+    border: none;
+
+    .r-grid-head {
+        display: none;
+    }
+
+    .r-grid-body {
+        @include make-row;
+        margin-left: -$grid-gutter-width;
+        margin-right: -$grid-gutter-width;
+        position: relative;
+        border: none;
+
+        .r-grid-row {
+            padding: $grid-gutter-width/2;
+
+            @include media-breakpoint-up(xs) {
+                @include make-col(12);
+            }
+
+            @include media-breakpoint-up(sm) {
+                @include make-col(6);
+            }
+
+            @include media-breakpoint-up(md) {
+                @include make-col(6);
+            }
+
+            @include media-breakpoint-up(lg) {
+                @include make-col(4);
+            }
+
+            @include media-breakpoint-up(xl) {
+                @include make-col(3);
+            }
+
+            &:nth-of-type(odd) .r-grid-cell {
+                background-color: $table-accent-bg;
+            }
+
+            &:hover .r-grid-cell {
+                background-color: $table-hover-bg;
+            }
+
+            &.ui-sortable-helper {
+                float: none;
+            }
+
+            .r-grid-cell {
+                background-color: $table-bg;
+                border: 1px solid $table-border-color;
+                border-bottom: none;
+                display: block;
+                line-height: $line-height-base;
+                padding: $table-cell-padding;
+                width: 100%;
+
+                &:last-child {
+                    border-bottom: 1px solid $table-border-color;
+                }
+
+                .cell-label {
+                    display: block;
+                    font-weight: bold;
+
+                    a {
+                        color: $body-color;
+                        cursor: default;
+
+                        &:hover, &:focus, &:active {
+                            text-decoration: none;
+                        }
+                    }
+                }
+
+                &.actions {
+                    display: inline-block;
+                    text-align: center;
+                    white-space: nowrap;
+                    width: 100%;
+
+                    .cell-label {
+                        display: none;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
4 new templates added for list modules with responsive grid render mode as scss mixins.

Mixins:
  - make-r-grid-table-view (display table, classic table)
  - make-r-grid-flex-table-view (display flex)
  - make-r-grid-card-view (display block, one card at each row)
  - make-r-grid-flex-card-view (display flex, bootstrap 4 grid system)

FrontEnd and FrontEnd-Modal scss files updated for default template of responsive grid. User can change it and apply their own style.